### PR TITLE
Fix print format

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ func vimOrTreat() {
 
 	err := startVim()
 	if err != nil {
-		fmt.Println("failed starting vim: %s", err.Error())
+		fmt.Printf("failed starting vim: %s\n", err.Error())
 	}
 }
 


### PR DESCRIPTION
An error of `go vet` was output.

```console
$ go vet
main.go:28: possible formatting directive in Println call
exit status 1
```

So, I fixed the bug of print format.