### PR TITLE
Specify filename

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ func startVim() error {
 	vim := exec.Command("vim", os.Args[1:]...)
 	vim.Stdin = os.Stdin
 	vim.Stdout = os.Stdout
+	vim.Stderr = os.Stderr
 
 	return vim.Run()
 }

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ func vimOrTreat() {
 }
 
 func startVim() error {
-	vim := exec.Command("vim")
+	vim := exec.Command("vim", os.Args[1:]...)
 	vim.Stdin = os.Stdin
 	vim.Stdout = os.Stdout
 


### PR DESCRIPTION
This PR provides the function of specifying the file name to open with vim.
Also includes addition of standard error output.

Usage:

```console
$ vim-or-treat README.md
```